### PR TITLE
Routing

### DIFF
--- a/docker-compose.custom.yml
+++ b/docker-compose.custom.yml
@@ -1,50 +1,146 @@
 version: '3'
 
+# services:
+#   shop:
+#     image: adalrsjr1/microservice
+#     container_name: front-end
+#     ports:
+#       - 8080:8080
+#     depends_on:
+#       - back-end-1
+#       - back-end-2
+#     command: --name=front-end --msg-size=128 --msg-time=10 --load=0.33 --mem=1 --zipkin=zipkin:9411 back-end-1 back-end-2
+
+#   back-end-1:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-1
+#     depends_on:
+#       - back-end-3
+#       - back-end-4
+#     command: --name=back-end-1 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-3 back-end-4
+
+#   back-end-2:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-2
+#     depends_on:
+#       - back-end-5
+#     command: --name=back-end-2 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-5
+
+#   back-end-3:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-3
+#     depends_on:
+#       - back-end-6
+#     command: --name=back-end-3 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-6
+
+#   back-end-4:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-4
+#     depends_on:
+#       - back-end-7
+#       - back-end-8
+#     command: --name=back-end-4 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-7 back-end-8
+
+#   back-end-5:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-5
+#     depends_on:
+#       - back-end-4
+#       - back-end-9
+#     command: --name=back-end-5 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-4 back-end-9
+
+#   back-end-6:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-6
+#     depends_on:
+#       - back-end-7
+#     command: --name=back-end-6 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-7
+
+#   back-end-7:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-7
+#     command: --name=back-end-7 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 
+
+#   back-end-8:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-8
+#     command: --name=back-end-8 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 
+
+#   back-end-9:
+#     image: adalrsjr1/microservice
+#     container_name: back-end-9
+#     command: --name=back-end-9 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 
+
 services:
-  shop:
+  svc_0:
+    command: --name=svc_0 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 svc_2
+    container_name: svc_0
+    depends_on:
+    - svc_2
     image: adalrsjr1/microservice
-    container_name: front-end
     ports:
-      - 8080:8080
+    - 8080:8080
+  svc_1:
+    command: --name=svc_1 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 svc_4 svc_6
+    container_name: svc_1
     depends_on:
-      - back-end-1
-      - back-end-2
-    command: --name=front-end --x=4.9 --y=4.9 --msg-size=128 --msg-time=10000 --load=0.33 --mem=1 --zipkin=zipkin:9411 back-end-1 back-end-2
-    #command: --name=front-end --msg-size=128 --msg-time=10 --load=0.33 --mem=1 --zipkin=zipkin:9411 back-end-1 back-end-2
-
-  back-end-1:
+    - svc_4
+    - svc_6
     image: adalrsjr1/microservice
-    container_name: back-end-1
+  svc_2:
+    command: --name=svc_2 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 svc_1
+    container_name: svc_2
     depends_on:
-      - back-end-3
-      - back-end-4
-    command: --name=back-end-1 --x=4.9 --y=4.9 --msg-size=256 --msg-time=10000 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-3 back-end-4
-    #command: --name=back-end-1 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-3 back-end-4
-
-  back-end-2:
+    - svc_1
     image: adalrsjr1/microservice
-    container_name: back-end-2
+  svc_3:
+    command: --name=svc_3 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 svc_8 svc_9
+    container_name: svc_3
     depends_on:
-      - back-end-5
-    command: --name=back-end-2 --x=4.9 --y=4.9 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-5
-    #command: --name=back-end-2 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411 back-end-5
-
-  back-end-3:
+    - svc_8
+    - svc_9
     image: adalrsjr1/microservice
-    container_name: back-end-3
-    command: --name=back-end-3 --x=4.9 --y=4.9 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411
-    #command: --name=back-end-3 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411
-
-  back-end-4:
+  svc_4:
+    command: --name=svc_4 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 svc_3 svc_5
+    container_name: svc_4
+    depends_on:
+    - svc_3
+    - svc_5
     image: adalrsjr1/microservice
-    container_name: back-end-4
-    command: --name=back-end-4 --x=4.9 --y=4.9 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411
-    #command: --name=back-end-4 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411
-
-  back-end-5:
+  svc_5:
+    command: '--name=svc_5 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 '
+    container_name: svc_5
+    depends_on: []
     image: adalrsjr1/microservice
-    container_name: back-end-5
-    command: --name=back-end-5 --x=4.9 --y=4.9 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411
-    #command: --name=back-end-5 --msg-size=256 --msg-time=30 --load=0.60 --mem=1 --zipkin=zipkin:9411
-
+  svc_6:
+    command: '--name=svc_6 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 '
+    container_name: svc_6
+    depends_on: []
+    image: adalrsjr1/microservice
+  svc_7:
+    command: '--name=svc_7 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 '
+    container_name: svc_7
+    depends_on: []
+    image: adalrsjr1/microservice
+  svc_8:
+    command: --name=svc_8 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 svc_7
+    container_name: svc_8
+    depends_on:
+    - svc_7
+    image: adalrsjr1/microservice
+  svc_9:
+    command: '--name=svc_9 --zipkin=zipkin:9411 --msg-size=100 --msg-time=100 --load=0.35
+      --mem=0 '
+    container_name: svc_9
+    depends_on: []
+    image: adalrsjr1/microservice
 

--- a/routeMap.go
+++ b/routeMap.go
@@ -1,0 +1,3 @@
+package main
+
+var generatedRouteMap = map[string]map[string]string{"0": {"svc_0": "svc_2", "svc_2": "svc_1", "svc_1": "svc_6", "svc_6": ""}, "1": {"svc_0": "svc_2", "svc_2": "svc_1", "svc_1": "svc_4", "svc_4": "svc_5", "svc_5": ""}, "2": {"svc_0": "svc_2", "svc_2": "svc_1", "svc_1": "svc_4", "svc_4": "svc_3", "svc_3": "svc_9", "svc_9": ""}, "3": {"svc_0": "svc_2", "svc_2": "svc_1", "svc_1": "svc_4", "svc_4": "svc_3", "svc_3": "svc_8", "svc_8": "svc_7", "svc_7": ""}}

--- a/router.go
+++ b/router.go
@@ -31,8 +31,6 @@ func main() {
 		memUsage   uint
 		zipkinAddr string
 		isSampling bool
-		x          float64
-		y          float64
 	)
 
 	flag.StringVar(&zipkinAddr, "zipkin", "0.0.0.0:9411", "zipkin addr:port default 0.0.0.0:9411")
@@ -42,8 +40,6 @@ func main() {
 	flag.UintVar(&msgTime, "msg-time", 10, "Time do compute an msg-request default 10ms")
 	flag.UintVar(&memUsage, "mem", 128, "min memory usage default:128MB")
 	flag.BoolVar(&isSampling, "sampling", true, "sampling messages to store into zipkin")
-	flag.Float64Var(&x, "x", 0, "x value")
-	flag.Float64Var(&y, "y", 0, "y value")
 	flag.Parse()
 	addrs := flag.Args()
 
@@ -78,23 +74,33 @@ func main() {
 
 	rand.Seed(42)
 
-	SetMemUsage(x, y)
+	SetMemUsage(memUsage)
 
 	r := mux.NewRouter()
 
 	if len(addrs) != 0 {
 
-		log.Printf("setting non-terminal handlers in %s", name)
+		log.Printf("setting non-terminal handlers in %s ___________________", name)
 
-		r.Methods("POST").Path("/").HandlerFunc(AllTargets(client, addrs[:], msgSize, msgTime, load, x, y))
-		r.Methods("POST").Path("/random").HandlerFunc(RandomTarget(client, addrs[:], msgSize, msgTime, load, x, y))
+		r.Methods("POST").Path("/").HandlerFunc(AllTargets(client, addrs[:], msgSize, msgTime, load))
+		r.Methods("POST").Path("/random").HandlerFunc(RandomTarget(client, addrs[:], msgSize, msgTime, load))
+
+		r.Methods("POST").Path("/0").HandlerFunc(handleRequest(name, client, addrs[:], msgSize, msgTime, load, "0"))
+		r.Methods("POST").Path("/1").HandlerFunc(handleRequest(name, client, addrs[:], msgSize, msgTime, load, "1"))
+		r.Methods("POST").Path("/2").HandlerFunc(handleRequest(name, client, addrs[:], msgSize, msgTime, load, "2"))
+		r.Methods("POST").Path("/3").HandlerFunc(handleRequest(name, client, addrs[:], msgSize, msgTime, load, "3"))
 
 	} else {
 
 		log.Printf("setting terminal handlers in %s", name)
 
-		r.Methods("POST").Path("/").HandlerFunc(TerminationRequest(client, name, addrs[:], msgSize, msgTime, load, x, y))
-		r.Methods("POST").Path("/random").HandlerFunc(TerminationRequest(client, name, addrs[:], msgSize, msgTime, load, x, y))
+		r.Methods("POST").Path("/").HandlerFunc(TerminationRequest(client, name, addrs[:], msgSize, msgTime, load))
+		r.Methods("POST").Path("/random").HandlerFunc(TerminationRequest(client, name, addrs[:], msgSize, msgTime, load))
+
+		r.Methods("POST").Path("/0").HandlerFunc(handleRequest(name, client, addrs[:], msgSize, msgTime, load, "0"))
+		r.Methods("POST").Path("/1").HandlerFunc(handleRequest(name, client, addrs[:], msgSize, msgTime, load, "1"))
+		r.Methods("POST").Path("/2").HandlerFunc(handleRequest(name, client, addrs[:], msgSize, msgTime, load, "2"))
+		r.Methods("POST").Path("/3").HandlerFunc(handleRequest(name, client, addrs[:], msgSize, msgTime, load, "3"))
 
 	}
 
@@ -112,15 +118,122 @@ func writePid() {
 	ioutil.WriteFile("/tmp/go.pid", bpid, 0644)
 }
 
-func AllTargets(client *zipkinhttp.Client, targets []string, requestSize uint, calculationTime uint, load float64, x float64, y float64) http.HandlerFunc {
+func getNextTarget(currentNode string, requestType string) string {
+
+	// var routeMap = map[string]map[string]string{
+	// 	"0": {
+	// 		"svc_0": "svc_2",
+	// 		"svc_2": "svc_1",
+	// 		"svc_1": "svc_6",
+	// 		"svc_6": ""},
+	// 	"1": {
+	// 		"svc_0": "svc_2",
+	// 		"svc_2": "svc_1",
+	// 		"svc_1": "svc_4",
+	// 		"svc_4": "svc_5",
+	// 		"svc_5": ""},
+	// 	"2": {
+	// 		"svc_0": "svc_2",
+	// 		"svc_2": "svc_1",
+	// 		"svc_1": "svc_4",
+	// 		"svc_4": "svc_3",
+	// 		"svc_3": "svc_9",
+	// 		"svc_9": ""},
+	// 	"3": {
+	// 		"svc_0": "svc_2",
+	// 		"svc_2": "svc_1",
+	// 		"svc_1": "svc_4",
+	// 		"svc_4": "svc_3",
+	// 		"svc_3": "svc_8",
+	// 		"svc_8": "svc_7",
+	// 		"svc_7": ""}}
+
+	nextNode := generatedRouteMap[requestType][currentNode]
+
+	return nextNode
+}
+
+func handleRequest(name string, client *zipkinhttp.Client, targets []string, requestSize uint, calculationTime uint, load float64, requestType string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("ok")
-		CallAllTargets(w, r, client, targets[:], requestSize, calculationTime, load, x, y)
+		traverseTargets(name, w, r, client, targets[:], requestSize, calculationTime, load, requestType)
 	}
 }
 
-func CallAllTargets(w http.ResponseWriter, r *http.Request, client *zipkinhttp.Client, targets []string, requestSize uint, calculationTime uint, load float64, x float64, y float64) {
-	FinityCpuUsage(calculationTime, x, y)
+// Traverse the path defined for that requestType in the generatedRouteMap
+func traverseTargets(name string, w http.ResponseWriter, r *http.Request,
+	client *zipkinhttp.Client, targets []string, requestSize uint,
+	calculationTime uint, load float64, requestType string) {
+
+	span, ctx := tracer.StartSpanFromContext(r.Context(), "size")
+
+	if span == nil {
+		log.Printf("span is nil")
+	}
+
+	span.Tag("termination_node", "false")
+
+	FinityCpuUsage(calculationTime, load)
+	span.Annotate(time.Now(), "expensive_calc_done")
+
+	byteMessage := make([]byte, integerNormalDistribution(requestSize, 10))
+
+	target := getNextTarget(name, requestType)
+
+	if target != "" {
+		log.Printf("-->" + target)
+		newRequest, err := http.NewRequest("POST", "http://"+target+":8080/"+requestType, bytes.NewBuffer(byteMessage))
+		span.Tag("source", globalName)
+		span.Tag("target", target)
+		span.Tag("req-size", strconv.Itoa(binary.Size(byteMessage)))
+
+		if err != nil {
+			log.Printf("unable to create client: %+v\n", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer span.Finish()
+
+		byteMessage = nil
+
+		ctx = zipkin.NewContext(newRequest.Context(), span)
+		newRequest = newRequest.WithContext(ctx)
+
+		res, err := client.DoWithAppSpan(newRequest, "random "+target)
+		if err != nil {
+			log.Printf("call to %s returned error: %+v\n", target, err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		bodyBytes, _ := ioutil.ReadAll(res.Body)
+		span.Tag("res-size", strconv.Itoa(binary.Size(bodyBytes)))
+		res.Body.Close()
+		w.Write(bodyBytes)
+	} else {
+		log.Printf("termination")
+
+		byteMessage := make([]byte, integerNormalDistribution(requestSize, 10))
+		w.Header().Set("Content-Type", "octect-stream")
+		w.Write(byteMessage)
+
+		span, _ := tracer.StartSpanFromContext(r.Context(), "size")
+		span.Tag("termination_node", "true")
+		timeElapsed := FinityCpuUsage(calculationTime, load)
+		span.Tag("elapsed_time_ms", strconv.FormatInt(int64(timeElapsed/time.Millisecond), 10))
+
+		span.Finish()
+	}
+}
+
+func AllTargets(client *zipkinhttp.Client, targets []string, requestSize uint, calculationTime uint, load float64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("ok")
+		CallAllTargets(w, r, client, targets[:], requestSize, calculationTime, load)
+	}
+}
+
+func CallAllTargets(w http.ResponseWriter, r *http.Request, client *zipkinhttp.Client, targets []string, requestSize uint, calculationTime uint, load float64) {
+	FinityCpuUsage(calculationTime, load)
 	byteMessage := make([]byte, integerNormalDistribution(requestSize, 10))
 
 	var bodyBytes []byte
@@ -168,16 +281,16 @@ func integerNormalDistribution(mean uint, dev uint) uint {
 //  return rand.NormFloat64() * dev + mean
 //}
 
-func RandomTarget(client *zipkinhttp.Client, targets []string, requestSize uint, calculationTime uint, load float64, x float64, y float64) http.HandlerFunc {
+func RandomTarget(client *zipkinhttp.Client, targets []string, requestSize uint, calculationTime uint, load float64) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		CallRandomTarget(w, r, client, targets[:], requestSize, calculationTime, load, x, y)
+		CallRandomTarget(w, r, client, targets[:], requestSize, calculationTime, load)
 	}
 }
 
 func CallRandomTarget(w http.ResponseWriter, r *http.Request,
 	client *zipkinhttp.Client, targets []string, requestSize uint,
-	calculationTime uint, load float64, x float64, y float64) {
+	calculationTime uint, load float64) {
 
 	span, ctx := tracer.StartSpanFromContext(r.Context(), "size") //zipkin.SpanFromContext(r.Context())
 	//span := zipkin.SpanFromContext(r.Context())
@@ -188,7 +301,7 @@ func CallRandomTarget(w http.ResponseWriter, r *http.Request,
 
 	span.Tag("termination_node", "false")
 
-	FinityCpuUsage(calculationTime, x, y)
+	FinityCpuUsage(calculationTime, load)
 	span.Annotate(time.Now(), "expensive_calc_done")
 
 	byteMessage := make([]byte, integerNormalDistribution(requestSize, 10))
@@ -236,7 +349,7 @@ func randomSelection(targets []string) string {
 	return selected
 }
 
-func TerminationRequest(client *zipkinhttp.Client, name string, targets []string, requestSize uint, calculationTime uint, load float64, x float64, y float64) http.HandlerFunc {
+func TerminationRequest(client *zipkinhttp.Client, name string, targets []string, requestSize uint, calculationTime uint, load float64) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		log.Printf("into %s", name)
@@ -257,7 +370,7 @@ func TerminationRequest(client *zipkinhttp.Client, name string, targets []string
 			//span.Tag("source", globalName)
 			//span.Tag("target", "terminal")
 			//span.Tag("req-size", strconv.Itoa(binary.Size(byteMessage)))
-			timeElapsed := FinityCpuUsage(calculationTime, x, y)
+			timeElapsed := FinityCpuUsage(calculationTime, load)
 			span.Tag("elapsed_time_ms", strconv.FormatInt(int64(timeElapsed/time.Millisecond), 10))
 			// the timeElapsed above must be Time
 			// span.Annotate(timeElapsed, "time elapsed")

--- a/uApp-generator/uApp-generator.py
+++ b/uApp-generator/uApp-generator.py
@@ -60,17 +60,6 @@ class Graph:
         nx.draw(self.g,pos, arrows=True)
         nx.draw_networkx_labels(self.g, pos, labels)
         plt.savefig('graph.pdf')
-
-    # def getPaths(self, start, path=[]):
-    #     path = path + [start]
-    #     paths = [path]
-    #     if len(self.g[start]) == 0:  # No neighbors
-    #         print(path)
-    #     for node in self.g[start]:
-    #         newpaths = self.getPaths(node, path)
-    #         for newpath in newpaths:
-    #             paths.append(newpath)
-    #     return paths
     
     def getPaths(self):
         paths = []


### PR DESCRIPTION
**uApp-generator.py**

- The `getPaths()` member function will get all the paths of a given graph
- The `pathsToMap()` member function converts this list of paths to a map formatted for Golang
- Then at the end of the file, both these functions are called, and the map is saved to a file called `routeMap.go`


**router.Go**

- In `main` new endpoints are added 0 through 3
- The handler function is `handleRequest()`, which calls `traverseTargets()` which is similar to call random targets, but instead of calling a random target, is selects the next target using `getNextTarget()` which reads the map from `routeMap.go` and selects the next target in the path associated with the endpoint 0-3

**How it Works**
- If you made a request to `localhost:8080/0` the router will direct the requests down the first path of the graph found in the route map, a request to `localhost:8080/1` will bring you down the second, an so on up to `/3`. I had to hardcode a certain number of endpoints, because I couldn't find how to parse the end of the URL for the number. The behaviour is unstable if you make a call to an endpoint with a number higher than the amount of paths through that graph.
- The ending to the URL is the only thing that controls the routing, otherwise you can still use the `/random` or no slug at all.