### PR TITLE
Fix RequestsPerSecond, use new function for y_1

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,28 +70,30 @@ All parameters are continuous unless otherwise specified.
 -4 <= a <= 4
 -250 <= b <= 250
 -10 <= c <= 10
-1E-5 <= d <= 1E5 | Step: 10, not continuous
+1E-5 <= d <= 1E-1 (continuous), 10 <= d <= 1E5 | Step: 10, not continuous
 -2.5 <= e <= 2.5
 5 <= f <= 10, -10 <= f <= -5
 -3 <= g <= 3
 -25 <= h < 25
 -10 <= x, y <= 10 | Step: 1, not continuous
 ```
+All parameters are independent of each other.
 
 #### Functions used to determine CPU and load
-![Functions](https://quicklatex.com/cache3/51/ql_249ec8fb1972a1d0d2346a148dd01751_l3.png)
+![Functions](https://quicklatex.com/cache3/76/ql_be0aa52379850f1f5b576bc689a00e76_l3.png)
 
 #### Raw functions
-If the images ever break, here are the raw functions (as LaTeX):
+If the image ever breaks, here are the raw functions (as LaTeX):
 ```
 Beale: \textrm{CPU} = \frac{(1.5-x+xy)^2 + (2.25-x+xy^2)^2 + (2.625-x+xy^3)^2}{890000} + 0.2
+
 Himmelblau: \textrm{Memory} =  \frac{(x^2 + y - 11)^2 + (x + y^2 - 7)^2}{890} * 1024
 
 x_{1}: \frac{a^2 + bc}{500*\log{d}} * 1024
 
 x_{2} = \log{d} - \frac{e*h}{32}
 
-y_{1} = \sin{\frac{a}{c} \pi } * cos(f^g \pi) - 2e
+y_{1} = \sin{\frac{a}{c} \pi } * cos(f*g \pi) - 2e
 
 y_{2} =  \frac{\sqrt{be}}{f}
 ```

--- a/metrics.go
+++ b/metrics.go
@@ -124,7 +124,7 @@ func beale(x float64, y float64) float64 {
 func himmelblau(x float64, y float64) uint {
 	var pct = 0.0
 	if x >= -5 && x <= 5 && y >= -5 && y <= 5 {
-		// Beale Function
+		// Himmelblau Function
 		pct = math.Pow(math.Pow(x, 2)+y-11, 2) + math.Pow(x+math.Pow(y, 2)-7, 2)
 		// Maximum for this function is approx. 890
 		pct = pct / 890 // make it a value between 0 and 1
@@ -150,7 +150,7 @@ func func_x_1(a float64, b float64, c float64, d float64) float64 {
 
 func func_y_1(a float64, c float64, e float64, f float64, g float64) float64 {
 	// sin(a*c*pi) * cos(f^g*pi) - 2*e
-	return (math.Sin((a/c)*math.Pi)*math.Cos((math.Pow(f, g))*math.Pi) - 2*e)
+	return (math.Sin((a/c)*math.Pi)*math.Cos(f*g*math.Pi) - 2*e)
 }
 
 func func_x_2(d float64, e float64, h float64) float64 {

--- a/router.go
+++ b/router.go
@@ -115,7 +115,7 @@ func main() {
 
 	//calculate the number of requests per second that are handled on average based on the CPU load and processing time
 	load := getCpuUsage(x, y, a, b, c, d, e, f, g, h)
-	microservice.RequestsPerSecond = int((load * 100.0) / float64((float64(microservice.ProcessTime) / 1000.0)))
+	microservice.RequestsPerSecond = int(load / float64((float64(microservice.ProcessTime) / 1000.0)))
 
 	bufferReader = NewQueue(microservice.RequestsPerSecond)
 


### PR DESCRIPTION
Use new function for y_1 due to NaN when using a negative number as a base for exponents; scale back requestsPerSecond by a factor of 100 to revert to previous behaviour